### PR TITLE
Add support for alternate UID format

### DIFF
--- a/imap_tools/main.py
+++ b/imap_tools/main.py
@@ -244,8 +244,8 @@ class MailMessage:
     @lru_cache()
     def uid(self) -> str or None:
         """Message UID"""
-        # zimbra, yandex, gmail
-        uid_match = re.search(r'\(UID (?P<uid>\d+) RFC822', self._raw_uid_data.decode())
+        # zimbra, yandex, gmail, gmx
+        uid_match = re.search(r'\(UID (?P<uid>\d+) (RFC822|FLAGS)', self._raw_uid_data.decode())
         if uid_match:
             return uid_match.group('uid')
         # mail.ru, ms exchange server


### PR DESCRIPTION
Some IMAP providers ([GMX] among others) include `FLAGS` in the `UID` command like shown in the following retrieved bytes:

```
1 (UID 2 FLAGS (\\Flagged \\Seen) RFC822 {177418}
```

This format does not trigger the `UID` regex as it expects the `UID` to be followed by `RFC822`. This pull request extends the expectation to include `FLAGS`.

[GMX]: https://gmx.com