### PR TITLE
Actions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,24 +63,24 @@ Email attributes
     # NOTE: All message properties are cached by functools.lru_cache
 
     for message in mailbox.fetch():
-        message.uid          # str or None, '123'
-        message.subject      # str, 'some subject'
-        message.from_        # str, 'sender@ya.ru'
-        message.to           # tuple, ('iam@goo.ru', 'friend@ya.ru', )
-        message.cc           # tuple, ('cc@mail.ru', )
-        message.bcc          # tuple, ('bcc@mail.ru', )
-        message.date         # datetime.datetime, 1900-1-1 for unparsed, may be naive or with tzinfo
-        message.text         # str, 'hi'
-        message.html         # str, '<b>hi</b>'
-        message.flags        # tuple, ('SEEN', 'FLAGGED', 'ENCRYPTED')
-        message.headers      # dict, {'Received': ('from 1.m.net', 'from 2.m.net'), 'AntiVirus': ('Clean',)}
-        message.attachments  # [(str, bytes)], 'cat.jpg', b'\xff\xd8\xff\xe0\'
-        message.obj          # original email.message.Message object
-        message.from_values  # dict or None, {'email': 'im@ya.ru', 'name': 'Ivan', 'full': 'Ivan <im@ya.ru>'}
-        message.to_values    # tuple, ({'email': '', 'name': '', 'full': ''},)
-        message.cc_values    # tuple, ({'email': '', 'name': '', 'full': ''},)
-        message.bcc_values   # tuple, ({'email': '', 'name': '', 'full': ''},)
-        message.date_str     # original date str, 'Tue, 03 Jan 2017 22:26:59 +0500'
+        message.uid          # str or None: '123'
+        message.subject      # str: 'some subject'
+        message.from_        # str: 'sender@ya.ru'
+        message.to           # tuple: ('iam@goo.ru', 'friend@ya.ru', )
+        message.cc           # tuple: ('cc@mail.ru', )
+        message.bcc          # tuple: ('bcc@mail.ru', )
+        message.date         # datetime.datetime: 1900-1-1 for unparsed, may be naive or with tzinfo
+        message.text         # str: 'hi'
+        message.html         # str: '<b>hi</b>'
+        message.flags        # tuple: ('SEEN', 'FLAGGED', 'ENCRYPTED')
+        message.headers      # dict: {'Received': ('from 1.m.net', 'from 2.m.net'), 'AntiVirus': ('Clean',)}
+        message.attachments  # [(str, bytes)]: 'cat.jpg', b'\xff\xd8\xff\xe0\'
+        message.obj          # email.message.Message: original object
+        message.from_values  # dict or None: {'email': 'im@ya.ru', 'name': 'Ivan', 'full': 'Ivan <im@ya.ru>'}
+        message.to_values    # tuple: ({'email': '', 'name': '', 'full': ''},)
+        message.cc_values    # tuple: ({'email': '', 'name': '', 'full': ''},)
+        message.bcc_values   # tuple: ({'email': '', 'name': '', 'full': ''},)
+        message.date_str     # str: original date - 'Tue, 03 Jan 2017 22:26:59 +0500'
 
 Search criteria
 ^^^^^^^^^^^^^^^
@@ -181,7 +181,7 @@ Result of MailBox.fetch generator will be implicitly converted to uid list.
         mailbox.delete([msg.uid for msg in mailbox.fetch()])
 
         # FLAG unseen messages in current folder as Answered and Flagged, *in bulk.
-        flags = (imap_tools.StandardMessageFlags.ANSWERED, imap_tools.StandardMessageFlags.FLAGGED)
+        flags = (imap_tools.MessageFlags.ANSWERED, imap_tools.MessageFlags.FLAGGED)
         mailbox.flag(mailbox.fetch('(UNSEEN)'), flags, True)
 
         # SEEN: mark all messages sent at 05.03.2007 in current folder as unseen, *in bulk
@@ -193,8 +193,8 @@ Actions with mailbox folders
 
     with MailBox('imap.mail.com').login('test@mail.com', 'pwd') as mailbox:
         # LIST
-        for folder in mailbox.folder.list('INBOX'):
-            print(folder['flags'], folder['delim'], folder['name'])
+        for f in mailbox.folder.list('INBOX'):
+            print((f['name'], f['flags'], f['delim']))  # ('INBOX|cats', '\\Unmarked \\HasChildren', '|')
         # SET
         mailbox.folder.set('INBOX')
         # GET

--- a/imap_tools/folder.py
+++ b/imap_tools/folder.py
@@ -91,7 +91,7 @@ class MailBoxFolderManager:
     def list(self, folder: str or bytes = '', search_args: str = '*', subscribed_only: bool = False) -> list:
         """
         Get a listing of folders on the server
-        :param folder: mailbox folder, if empty list shows all content from root
+        :param folder: mailbox folder, if empty - get from root
         :param search_args: search argumets, is case-sensitive mailbox name with possible wildcards
             * is a wildcard, and matches zero or more characters at this position
             % is similar to * but it does not match a hierarchy delimiter

--- a/imap_tools/mailbox.py
+++ b/imap_tools/mailbox.py
@@ -108,35 +108,53 @@ class MailBox:
         check_command_status('box.expunge', result)
         return result
 
-    def delete(self, uid_list) -> tuple:
-        """Delete email messages"""
+    def delete(self, uid_list) -> (tuple, tuple) or None:
+        """
+        Delete email messages
+        Do nothing on empty uid_list
+        """
         uid_str = cleaned_uid_set(uid_list)
+        if not uid_str:
+            return None
         store_result = self.box.uid('STORE', uid_str, '+FLAGS', r'(\Deleted)')
         check_command_status('box.delete', store_result)
         expunge_result = self.expunge()
         return store_result, expunge_result
 
     def copy(self, uid_list, destination_folder: str) -> tuple or None:
-        """Copy email messages into the specified folder"""
+        """
+        Copy email messages into the specified folder
+        Do nothing on empty uid_list
+        """
         uid_str = cleaned_uid_set(uid_list)
+        if not uid_str:
+            return None
         copy_result = self.box.uid('COPY', uid_str, destination_folder)
         check_command_status('box.copy', copy_result)
         return copy_result
 
-    def move(self, uid_list, destination_folder: str) -> tuple:
-        """Move email messages into the specified folder"""
+    def move(self, uid_list, destination_folder: str) -> (tuple, tuple) or None:
+        """
+        Move email messages into the specified folder
+        Do nothing on empty uid_list
+        """
         # here for avoid double fetch in uid_set
         uid_str = cleaned_uid_set(uid_list)
+        if not uid_str:
+            return None
         copy_result = self.copy(uid_str, destination_folder)
         delete_result = self.delete(uid_str)
         return copy_result, delete_result
 
-    def flag(self, uid_list, flag_set: [str] or str, value: bool) -> tuple:
+    def flag(self, uid_list, flag_set: [str] or str, value: bool) -> (tuple, tuple) or None:
         """
         Set/unset email flags
+        Do nothing on empty uid_list
         Standard flags contains in StandardMessageFlags.all
         """
         uid_str = cleaned_uid_set(uid_list)
+        if not uid_str:
+            return None
         if type(flag_set) is str:
             flag_set = [flag_set]
         store_result = self.box.uid(
@@ -146,7 +164,7 @@ class MailBox:
         expunge_result = self.expunge()
         return store_result, expunge_result
 
-    def seen(self, uid_list, seen_val: bool) -> tuple:
+    def seen(self, uid_list, seen_val: bool) -> (tuple, tuple) or None:
         """
         Mark email as read/unread
         This is shortcut for flag method

--- a/imap_tools/mailbox.py
+++ b/imap_tools/mailbox.py
@@ -8,7 +8,7 @@ from .utils import cleaned_uid_set, check_command_status
 imaplib._MAXLINE = 4 * 1024 * 1024  # 4Mb
 
 
-class StandardMessageFlags:
+class MessageFlags:
     """Standard email message flags"""
     SEEN = 'SEEN'
     ANSWERED = 'ANSWERED'
@@ -112,6 +112,7 @@ class MailBox:
         """
         Delete email messages
         Do nothing on empty uid_list
+        :return: None on empty uid_list, command results otherwise
         """
         uid_str = cleaned_uid_set(uid_list)
         if not uid_str:
@@ -125,6 +126,7 @@ class MailBox:
         """
         Copy email messages into the specified folder
         Do nothing on empty uid_list
+        :return: None on empty uid_list, command results otherwise
         """
         uid_str = cleaned_uid_set(uid_list)
         if not uid_str:
@@ -137,6 +139,7 @@ class MailBox:
         """
         Move email messages into the specified folder
         Do nothing on empty uid_list
+        :return: None on empty uid_list, command results otherwise
         """
         # here for avoid double fetch in uid_set
         uid_str = cleaned_uid_set(uid_list)
@@ -150,7 +153,8 @@ class MailBox:
         """
         Set/unset email flags
         Do nothing on empty uid_list
-        Standard flags contains in StandardMessageFlags.all
+        Standard flags contains in MessageFlags.all
+        :return: None on empty uid_list, command results otherwise
         """
         uid_str = cleaned_uid_set(uid_list)
         if not uid_str:
@@ -169,7 +173,7 @@ class MailBox:
         Mark email as read/unread
         This is shortcut for flag method
         """
-        return self.flag(uid_list, StandardMessageFlags.SEEN, seen_val)
+        return self.flag(uid_list, MessageFlags.SEEN, seen_val)
 
     def __enter__(self):
         return self

--- a/imap_tools/utils.py
+++ b/imap_tools/utils.py
@@ -13,8 +13,6 @@ def cleaned_uid_set(uid_set: str or [str] or iter) -> str:
         Iterable, that contains str uids
         Generator with "fetch" name, implicitly gets all non-empty uids
     """
-    if not uid_set:
-        raise ValueError('uid_set should not be empty')
     if type(uid_set) is str:
         uid_set = uid_set.split(',')
     if inspect.isgenerator(uid_set) and getattr(uid_set, '__name__', None) == 'fetch':

--- a/imap_tools/utils.py
+++ b/imap_tools/utils.py
@@ -25,7 +25,7 @@ def cleaned_uid_set(uid_set: str or [str] or iter) -> str:
         if type(uid) is not str:
             raise ValueError('uid "{}" is not string'.format(str(uid)))
         if not uid.strip().isdigit():
-            raise ValueError('Wrong uid: {}'.format(uid))
+            raise ValueError('Wrong uid: "{}"'.format(uid))
     return ','.join((i.strip() for i in uid_set))
 
 

--- a/release_notes.rst
+++ b/release_notes.rst
@@ -1,3 +1,9 @@
+0.10.1
+======
+* utils.cleaned_uid_set now not raise ValueError('uid_set should not be empty')
+* mailbox.MailBox delete,copy,move,flag,seen methods changed: Do nothing on empty uid_list - return None
+* mailbox.StandardMessageFlags renamed to mailbox.MessageFlags
+
 0.9.4
 =====
 * MailMessage.from_bytes - Alternative constructor

--- a/release_notes.rst
+++ b/release_notes.rst
@@ -1,4 +1,4 @@
-0.10.1
+0.10.0
 ======
 * utils.cleaned_uid_set now not raise ValueError('uid_set should not be empty')
 * mailbox.MailBox delete,copy,move,flag,seen methods changed: Do nothing on empty uid_list - return None

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.rst", "r", encoding='utf-8') as fh:
 
 setuptools.setup(
     name='imap_tools',
-    version='0.9.9',
+    version='0.10.1',
     packages=setuptools.find_packages(),
     url='https://github.com/ikvk/imap_tools',
     license='Apache-2.0',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.rst", "r", encoding='utf-8') as fh:
 
 setuptools.setup(
     name='imap_tools',
-    version='0.10.1',
+    version='0.10.0',
     packages=setuptools.find_packages(),
     url='https://github.com/ikvk/imap_tools',
     license='Apache-2.0',

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -43,13 +43,13 @@ class ActionTest(MailboxTestCase):
 
             # FLAG
             mailbox.folder.set(mailbox.folder_test_temp2)
-            mailbox.flag([msg.uid for msg in mailbox.fetch()], imap_tools.StandardMessageFlags.FLAGGED, True)
-            self.assertTrue(all([imap_tools.StandardMessageFlags.FLAGGED in msg.flags for msg in mailbox.fetch()]))
+            mailbox.flag([msg.uid for msg in mailbox.fetch()], imap_tools.MessageFlags.FLAGGED, True)
+            self.assertTrue(all([imap_tools.MessageFlags.FLAGGED in msg.flags for msg in mailbox.fetch()]))
 
             # SEEN
             mailbox.folder.set(mailbox.folder_test_temp2)
             mailbox.seen([msg.uid for msg in mailbox.fetch()], False)
-            self.assertTrue(all([imap_tools.StandardMessageFlags.SEEN not in msg.flags
+            self.assertTrue(all([imap_tools.MessageFlags.SEEN not in msg.flags
                                  for msg in mailbox.fetch(mark_seen=False)]))
 
             # DELETE

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -22,7 +22,7 @@ class QueryTest(unittest.TestCase):
                 ('cleaned_uint', (0, 1, 145), (-1, 'str', [], {}, type, True, b'1')),
                 ('cleaned_str', ('', 'good', 'я 你好'), (1, [], {}, type, True, b'1')),
                 ('cleaned_true', (True,), (1, 'str', [], {}, type, False, b'1')),
-                ('cleaned_uid', ('1', '1,2', ['1', '2'], fetch()), (1, [], {}, type, True, b'1', not_fetch())),
+                ('cleaned_uid', ('1', '1,2', ['1', '2'], [], {}, fetch()), (1, type, True, b'1', '', not_fetch())),
                 ('cleaned_header', (H('X-Google-Smtp', '123'), H('a', '1')), (1, 's', ['s', 1], {}, type, False, b'1')),
         ):
             cleaned_fn = getattr(ParamConverter, cleaned_fn_name)

--- a/todo.txt
+++ b/todo.txt
@@ -3,3 +3,9 @@ try to imitate long poll by noop
 fetch INTERNALDATE The internal date of the message.
 
 message attributes strong tests
+
+--
+cleaned_uid_set not raise ValueError('uid_set should not be empty')
+MailBox delete,copy,move,flag,seen methods changed - now Do nothing on empty uid_list
+StandardMessageFlags renamed to MessageFlags
+fx readme

--- a/todo.txt
+++ b/todo.txt
@@ -1,11 +1,3 @@
 try to imitate long poll by noop
 
-fetch INTERNALDATE The internal date of the message.
-
 message attributes strong tests
-
---
-cleaned_uid_set not raise ValueError('uid_set should not be empty')
-MailBox delete,copy,move,flag,seen methods changed - now Do nothing on empty uid_list
-StandardMessageFlags renamed to MessageFlags
-fx readme


### PR DESCRIPTION
* utils.cleaned_uid_set now not raise ValueError('uid_set should not be empty')
* mailbox.MailBox delete,copy,move,flag,seen methods changed: Do nothing on empty uid_list - return None
* mailbox.StandardMessageFlags renamed to mailbox.MessageFlags
