### PR TITLE
Include content type of attachments.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,13 +74,16 @@ Email attributes
         message.html         # str: '<b>hi</b>'
         message.flags        # tuple: ('SEEN', 'FLAGGED', 'ENCRYPTED')
         message.headers      # dict: {'Received': ('from 1.m.net', 'from 2.m.net'), 'AntiVirus': ('Clean',)}
-        message.attachments  # [(str, bytes)]: 'cat.jpg', b'\xff\xd8\xff\xe0\'
         message.obj          # email.message.Message: original object
         message.from_values  # dict or None: {'email': 'im@ya.ru', 'name': 'Ivan', 'full': 'Ivan <im@ya.ru>'}
         message.to_values    # tuple: ({'email': '', 'name': '', 'full': ''},)
         message.cc_values    # tuple: ({'email': '', 'name': '', 'full': ''},)
         message.bcc_values   # tuple: ({'email': '', 'name': '', 'full': ''},)
         message.date_str     # str: original date - 'Tue, 03 Jan 2017 22:26:59 +0500'
+        for attachment in message.attachments:  # list of Attachment objects
+            attachment.filename                 # 'cat.jpg'
+            attachment.content_type             # 'image/jpeg'
+            attachment.body                     # b'\xff\xd8\xff\xe0\'
 
 Search criteria
 ^^^^^^^^^^^^^^^

--- a/imap_tools/message.py
+++ b/imap_tools/message.py
@@ -192,7 +192,7 @@ class MailMessage:
         Attachments of the mail message (generator)
         :return: [(filename: str, payload: bytes)]
         """
-        result = []
+        attachments = []
         for part in self.obj.walk():
             if part.get_content_maintype() == 'multipart':
                 # multipart/* are just containers
@@ -202,24 +202,41 @@ class MailMessage:
             filename = part.get_filename()
             if not filename:
                 continue  # this is what happens when Content-Disposition = inline
-            filename = decode_value(*decode_header(filename)[0])
-            payload = part.get_payload(decode=True)
-            if payload:
-                result.append((filename, payload))
-            else:
-                # multipart payload, such as .eml (see get_payload)
-                multipart_payload = part.get_payload()
-                if isinstance(multipart_payload, list):
-                    for payload_item in multipart_payload:
-                        if hasattr(payload_item, 'as_bytes'):
-                            payload_item_bytes = payload_item.as_bytes()
-                            cte = str(part.get('content-transfer-encoding', '')).lower().strip()
-                            if payload_item_bytes and cte:
-                                found_payload = b''
-                                if cte == 'base64':
-                                    found_payload = base64.b64decode(payload_item_bytes)
-                                elif cte in ('7bit', '8bit', 'quoted-printable', 'binary'):
-                                    found_payload = payload_item_bytes  # quopri.decodestring
-                                if found_payload:
-                                    result.append((filename, found_payload))
-        return result
+
+            attachments.append(Attachment(part))
+        return [(attachment.filename, attachment.body) for attachment in attachments]
+
+
+class Attachment:
+    """An attachment for a MailMessage"""
+    def __init__(self, part):
+        self._part = part
+
+    @property
+    @lru_cache()
+    def filename(self) -> str:
+        filename = self._part.get_filename()
+        return decode_value(*decode_header(filename)[0])
+
+    @property
+    @lru_cache()
+    def body(self) -> bytes:
+        body = self._part.get_body(decode=True)
+        if body:
+            return body
+        else:
+            # multipart body, such as .eml (see get_body)
+            multipart_body = self._part.get_body()
+            if isinstance(multipart_body, list):
+                for body_item in multipart_body:
+                    if hasattr(body_item, 'as_bytes'):
+                        body_item_bytes = body_item.as_bytes()
+                        cte = str(self._part.get('content-transfer-encoding', '')).lower().strip()
+                        if body_item_bytes and cte:
+                            found_body = b''
+                            if cte == 'base64':
+                                found_body = base64.b64decode(body_item_bytes)
+                            elif cte in ('7bit', '8bit', 'quoted-printable', 'binary'):
+                                found_body = body_item_bytes  # quopri.decodestring
+                            if found_body:
+                                return found_body

--- a/imap_tools/message.py
+++ b/imap_tools/message.py
@@ -204,7 +204,7 @@ class MailMessage:
                 continue  # this is what happens when Content-Disposition = inline
 
             attachments.append(Attachment(part))
-        return [(attachment.filename, attachment.body) for attachment in attachments]
+        return attachments
 
 
 class Attachment:
@@ -217,6 +217,12 @@ class Attachment:
     def filename(self) -> str:
         filename = self._part.get_filename()
         return decode_value(*decode_header(filename)[0])
+
+    @property
+    @lru_cache()
+    def content_type(self) -> str:
+        content_type = self._part.get_content_type()
+        return decode_value(*decode_header(content_type)[0])
 
     @property
     @lru_cache()

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -45,9 +45,10 @@ class MessageTest(MailboxTestCase):
                 for i in message.flags:
                     self.assertIs(type(i), str)
 
-                for filename, payload in message.attachments:
-                    self.assertIs(type(filename), str)
-                    self.assertIs(type(payload), bytes)
+                for attachment in message.attachments:
+                    self.assertIs(type(attachment.filename), str)
+                    self.assertIs(type(attachment.content_type), str)
+                    self.assertIs(type(attachment.payload), bytes)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hi! 👋

I wanted to get the content type of mail attachments, so I've extended `MailMessage.attachments` to include it.

`MailMessage.attachments` now returns a list of `Attachment` objects, which have `filename`, `body` and `content_type` properties. (This is a breaking change! However, any new properties on Attachment objects will not be breaking changes in the future.)

Let me know what you think!