### PR TITLE
Fixed multiple encodings case for attachment name

### DIFF
--- a/imap_tools/message.py
+++ b/imap_tools/message.py
@@ -218,7 +218,7 @@ class Attachment:
     @lru_cache()
     def filename(self) -> str:
         filename = self._part.get_filename()
-        return decode_value(*decode_header(filename)[0])
+        return ''.join(decode_value(*part) for part in decode_header(filename))
 
     @property
     @lru_cache()


### PR DESCRIPTION
A way to fix the multiply-encoded filenames in attachments. See https://github.com/ikvk/imap_tools/issues/33