### PR TITLE
Exclude tests package from distribution archive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ MANIFEST
 /examples/check.py
 /.python-version
 /.idea/
+/venv/

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open("README.rst", "r", encoding='utf-8') as fh:
 setuptools.setup(
     name='imap_tools',
     version=get_version('imap_tools'),
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=['tests']),
     url='https://github.com/ikvk/imap_tools',
     license='Apache-2.0',
     long_description=long_description,


### PR DESCRIPTION
I think distribution of tests is not necessary. And tests package in imap_tools may cause conflicts with own tests package in project