### PR TITLE
Fix folder status for folders with brackets

### DIFF
--- a/imap_tools/folder.py
+++ b/imap_tools/folder.py
@@ -102,7 +102,7 @@ class MailBoxFolderManager:
         result = self.mailbox.client._untagged_response(status_result[0], status_result[1], command)
         check_command_status(result, MailboxFolderStatusError)
         status_data = [i for i in result[1] if type(i) is bytes][0]  # may contain tuples with encoded names
-        values = status_data.decode().split('(')[1].split(')')[0].split(' ')
+        values = status_data.decode().split('(')[-1].split(')')[0].split(' ')
         return {k: int(v) for k, v in pairs_to_dict(values).items() if str(v).isdigit()}
 
     def list(self, folder: AnyStr = '', search_args: str = '*', subscribed_only: bool = False) -> List[FolderInfo]:


### PR DESCRIPTION
If folder name is "folder (name)" than `mailbox.folder.status("folder (name)")` raise exception due to wrong splitting

Logs of this case looks like this:
```
XX:XX.XX > b'XXXXX STATUS "folder (name)" (MESSAGES RECENT UIDNEXT UIDVALIDITY UNSEEN)'
XX:XX.XX < b'* STATUS "folder (name)" (MESSAGES X RECENT X UIDNEXT X UIDVALIDITY X UNSEEN X)'
```
