### PR TITLE
Add __repr__ to MailMessage

### DIFF
--- a/imap_tools/message.py
+++ b/imap_tools/message.py
@@ -222,6 +222,9 @@ class MailMessage:
             results.append(MailAttachment(part))
         return results
 
+    def __repr__(self) -> str:
+        return f"<imap_tools.message.MailMessage '{self.subject}'>"
+
 
 class MailAttachment:
     """An attachment for a MailMessage"""


### PR DESCRIPTION
This should help with debugging and logging, e.g. as is done in paperless-ngx:

[2024-04-11 14:50:01,613] [DEBUG] [paperless_mail] Skipping mail <imap_tools.message.MailMessage object at 0x7458141155d0>, already processed.