### PR TITLE
Fix list regexp

### DIFF
--- a/imap_tools/folder.py
+++ b/imap_tools/folder.py
@@ -115,7 +115,7 @@ class MailBoxFolderManager:
         :param subscribed_only: bool - get only subscribed folders
         :return: [FolderInfo]
         """
-        folder_item_re = re.compile(r'\((?P<flags>[\S ]*)\) (?P<delim>[\S]+) (?P<name>.+)')
+        folder_item_re = re.compile(r'\((?P<flags>([\S]*|[\S]+( [\S]+)*))\) (?P<delim>(\"[\S]+\"|NIL)) (?P<name>.+)')
         command = 'LSUB' if subscribed_only else 'LIST'
         typ, data = self.mailbox.client._simple_command(
             command, encode_folder(folder), encode_folder(search_args))


### PR DESCRIPTION
Fix regexp for parse RFC's mailbox-list format (https://datatracker.ietf.org/doc/html/rfc3501#page-87)

Old regexp not correctly  parse next samples:
```
(\HasNoChildren \Marked \Sent) "/" "INBOX/(01) FolderName1/(033) FolderName32"
(\HasNoChildren) "/" "INBOX/(01) FolderName1/(033) FolderName32"
```
