### PR TITLE
Fix double quotes in folder name

### DIFF
--- a/imap_tools/folder.py
+++ b/imap_tools/folder.py
@@ -132,6 +132,8 @@ class MailBoxFolderManager:
                 name = folder_dict['name']
                 if name.startswith('"') and name.endswith('"'):
                     name = name[1:-1]
+                if '\\"' in name:
+                    name = name.replace('\\"', '"')
             elif type(folder_item) is tuple:
                 # when name has " or \ chars
                 folder_match = re.search(folder_item_re, utf7_decode(folder_item[0]))


### PR DESCRIPTION
I have next LIST response: `LIST (\HasNoChildren) "/" "Folder/Subfolder \"i am subfolder\""`

at 134 line name will be `Folder/Subfolder \\"i am subfolder\\"`. 
and `encode_folder->quote` transform it to: `"Folder/Subfolder \\\\\\"i am subfolder\\\\\\""`

We need unquote it.